### PR TITLE
Fix error in editors when uploading file containing characters outside the Latin alphabet, re #9089

### DIFF
--- a/src/main/java/com/lorepo/icf/utils/FileUploader.java
+++ b/src/main/java/com/lorepo/icf/utils/FileUploader.java
@@ -125,8 +125,8 @@ public class FileUploader {
 
     public native static String createUploadedEndpoint(String successActionRedirect, String filename, String contentType) /*-{
         var encodeUnicodeStringToBase64 = $entry(function(unicodeString) {
-			return @com.lorepo.icf.utils.StringUtils::encodeUnicodeStringToBase64(Ljava/lang/String;)(unicodeString);
-		});
+            return @com.lorepo.icf.utils.StringUtils::encodeUnicodeStringToBase64(Ljava/lang/String;)(unicodeString);
+        });
 
         var metadata = {
             filename: filename,

--- a/src/main/java/com/lorepo/icf/utils/FileUploader.java
+++ b/src/main/java/com/lorepo/icf/utils/FileUploader.java
@@ -18,6 +18,7 @@ import com.google.gwt.user.client.ui.Hidden;
 import com.google.gwt.user.client.ui.Widget;
 
 import com.lorepo.icf.utils.JavaScriptUtils;
+import com.lorepo.icf.utils.StringUtils;
 
 
 public class FileUploader {
@@ -122,12 +123,17 @@ public class FileUploader {
         return hiddenWidget;
     }
 
-    public static native String createUploadedEndpoint(String successActionRedirect, String filename, String contentType) /*-{
+    public native static String createUploadedEndpoint(String successActionRedirect, String filename, String contentType) /*-{
+        var encodeUnicodeStringToBase64 = $entry(function(unicodeString) {
+			return @com.lorepo.icf.utils.StringUtils::encodeUnicodeStringToBase64(Ljava/lang/String;)(unicodeString);
+		});
+
         var metadata = {
             filename: filename,
             content_type: contentType
         };
-        var metadataStr = btoa(JSON.stringify(metadata));
+
+        var metadataStr = encodeUnicodeStringToBase64(JSON.stringify(metadata));
         return successActionRedirect + "&metadata=" + metadataStr;
     }-*/;
     

--- a/src/main/java/com/lorepo/icf/utils/StringUtils.java
+++ b/src/main/java/com/lorepo/icf/utils/StringUtils.java
@@ -372,4 +372,21 @@ public class StringUtils {
 		// + is to take care of multiple spaces one after another 
 		return str.replaceAll("\\s+",""); 
 	}
+
+	public native static String encodeUnicodeStringToBase64(String dataToConvert) /*-{
+        // Convert Unicode to byte array
+        var byteArray = new TextEncoder().encode(dataToConvert);
+
+        // Convert byte array to base64
+        return btoa(String.fromCharCode.apply(null, byteArray));
+    }-*/;
+
+    public static native String decodeBase64ToUnicodeString(String base64String) /*-{
+        var decodedByteArray = new Uint8Array(
+            atob(base64String)
+                .split('')
+                .map(function(character) {return character.charCodeAt(0)})
+        );
+        return new TextDecoder().decode(decodedByteArray);
+    }-*/;
 }

--- a/src/main/java/com/lorepo/icf/utils/StringUtils.java
+++ b/src/main/java/com/lorepo/icf/utils/StringUtils.java
@@ -379,15 +379,15 @@ public class StringUtils {
 		
 		// Convert byte array to base64
 		var convertedString = btoa(String.fromCodePoint.apply(null, byteArray));
-
+		
 		// convert not save URL characters (conversion adjusted to decode on the backend side)
-        return convertedString.replace('+', '-').replace('/', '_');
+		return convertedString.replace('+', '-').replace('/', '_');
 	}-*/;
 	
 	public native static String decodeBase64ToUnicodeString(String base64String) /*-{
 		// restore not save URL characters (conversion adjusted to encodeUnicodeStringToBase64)
-        var b64EncodedNotSaveURL = base64String.replace('-', '+').replace('_', '/');
-
+		var b64EncodedNotSaveURL = base64String.replace('-', '+').replace('_', '/');
+		
 		var decodedByteArray = Uint8Array.from(
 			atob(b64EncodedNotSaveURL),
 			function(character) {return character.codePointAt(0)}

--- a/src/main/java/com/lorepo/icf/utils/StringUtils.java
+++ b/src/main/java/com/lorepo/icf/utils/StringUtils.java
@@ -378,14 +378,19 @@ public class StringUtils {
 		var byteArray = new TextEncoder().encode(dataToConvert);
 		
 		// Convert byte array to base64
-		return btoa(String.fromCharCode.apply(null, byteArray));
+		var convertedString = btoa(String.fromCodePoint.apply(null, byteArray));
+
+		// convert not save URL characters (conversion adjusted to decode on the backend side)
+        return convertedString.replace('+', '-').replace('/', '_');
 	}-*/;
 	
-	public static native String decodeBase64ToUnicodeString(String base64String) /*-{
-		var decodedByteArray = new Uint8Array(
-			atob(base64String)
-				.split('')
-				.map(function(character) {return character.charCodeAt(0)})
+	public native static String decodeBase64ToUnicodeString(String base64String) /*-{
+		// restore not save URL characters (conversion adjusted to encodeUnicodeStringToBase64)
+        var b64EncodedNotSaveURL = base64String.replace('-', '+').replace('_', '/');
+
+		var decodedByteArray = Uint8Array.from(
+			atob(b64EncodedNotSaveURL),
+			function(character) {return character.codePointAt(0)}
 		);
 		return new TextDecoder().decode(decodedByteArray);
 	}-*/;

--- a/src/main/java/com/lorepo/icf/utils/StringUtils.java
+++ b/src/main/java/com/lorepo/icf/utils/StringUtils.java
@@ -374,19 +374,19 @@ public class StringUtils {
 	}
 
 	public native static String encodeUnicodeStringToBase64(String dataToConvert) /*-{
-        // Convert Unicode to byte array
-        var byteArray = new TextEncoder().encode(dataToConvert);
-
-        // Convert byte array to base64
-        return btoa(String.fromCharCode.apply(null, byteArray));
-    }-*/;
-
-    public static native String decodeBase64ToUnicodeString(String base64String) /*-{
-        var decodedByteArray = new Uint8Array(
-            atob(base64String)
-                .split('')
-                .map(function(character) {return character.charCodeAt(0)})
-        );
-        return new TextDecoder().decode(decodedByteArray);
-    }-*/;
+		// Convert Unicode to byte array
+		var byteArray = new TextEncoder().encode(dataToConvert);
+		
+		// Convert byte array to base64
+		return btoa(String.fromCharCode.apply(null, byteArray));
+	}-*/;
+	
+	public static native String decodeBase64ToUnicodeString(String base64String) /*-{
+		var decodedByteArray = new Uint8Array(
+			atob(base64String)
+				.split('')
+				.map(function(character) {return character.charCodeAt(0)})
+		);
+		return new TextDecoder().decode(decodedByteArray);
+	}-*/;
 }

--- a/src/main/java/com/lorepo/icf/utils/StringUtils.java
+++ b/src/main/java/com/lorepo/icf/utils/StringUtils.java
@@ -372,24 +372,39 @@ public class StringUtils {
 		// + is to take care of multiple spaces one after another 
 		return str.replaceAll("\\s+",""); 
 	}
-
+	
+	/**
+	 * Encode a string using the URL- and filesystem-safe Base64 alphabet.
+	 * 
+	 * The alphabet uses '-' instead of '+' and '_' instead of '/'.
+	 * Method is adjusted to decode method on the backend side.
+	 * 
+	 * @param dataToConvert string to encode
+	 * @return encoded string
+	 */
 	public native static String encodeUnicodeStringToBase64(String dataToConvert) /*-{
-		// Convert Unicode to byte array
 		var byteArray = new TextEncoder().encode(dataToConvert);
-		
-		// Convert byte array to base64
-		var convertedString = btoa(String.fromCodePoint.apply(null, byteArray));
-		
-		// convert not save URL characters (conversion adjusted to decode on the backend side)
-		return convertedString.replace('+', '-').replace('/', '_');
+		var convertedString = String.fromCodePoint.apply(null, byteArray);
+		return btoa(convertedString)
+			.replace(/\+/g, '-')
+			.replace(/\//g, '_');
 	}-*/;
 	
+	/**
+	 * Decode a URL- and filesystem-safe URL base64 string to unicode string.
+	 * 
+	 * @param base64String string to decode. String uses '-' instead of '+' and '_' instead of '/'.
+	 * @return decoded string
+	 */
 	public native static String decodeBase64ToUnicodeString(String base64String) /*-{
-		// restore not save URL characters (conversion adjusted to encodeUnicodeStringToBase64)
-		var b64EncodedNotSaveURL = base64String.replace('-', '+').replace('_', '/');
-		
+		var paddedEncodedText =
+			base64String + '='.repeat((4 - (base64String.length % 4)) % 4);
+		var base64 = paddedEncodedText
+			.replace(/-/g, '+')
+			.replace(/_/g, '/');
+			
 		var decodedByteArray = Uint8Array.from(
-			atob(b64EncodedNotSaveURL),
+			atob(base64),
 			function(character) {return character.codePointAt(0)}
 		);
 		return new TextDecoder().decode(decodedByteArray);


### PR DESCRIPTION
[Ticket](https://learneticsa.assembla.com/spaces/lorepo/tickets/9089--editor--problem-z-za%C5%82adowaniem-pliku-kt%C3%B3ry-ma-polskie-znaki/details)
[Wersja testowa](https://test-9089-dot-mauthor-dev.ew.r.appspot.com/)

Dowolny upload niezależnie od nazwy powinien się wykonać. Należy przetestować Editor i AddonEditor.
Powinno się przeprowadzić testy uwzględniając widoki jakie zostały wymienione w wyniku zadania https://learneticsa.assembla.com/spaces/lorepo/tickets/9065

Proszę porównać wynik zadania z wynikiem zadania w LC-9071 względem pliku gcs_user_upload.py . Zakodowany tekst jest odbierany w metodzie from_request i musi być odpowiednio decodowany.